### PR TITLE
Remove Firefox Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,34 @@
-# Debugger Experiment
+### Debugger Experiment
 
-## Getting Started
+#### Getting Started
 
-### 1. Install Dependencies
 ```js
 $ npm install
+$ npm start
 ```
 
-### 2. Add Environment file
-
-You'll need to add an `environment.json` file to set your path to the gecko repository.
-
-```json
-{ "geckoPath" : "/Users/jlaster/src/mozilla/gecko-dev"}
-```
-
-### 3. Start Firefox
-
-You need to start a new instance of Firefox that you will be
-debugging. Either press "shift+F2" and type "listen" in the new
-instance or use the command line flag:
+Start Firefox in remote debugging mode and go to a tab you want to debug.
 
 ```
 $ /Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin --start-debugger-server 6080
 ```
 
-### 4. Start Debugger.html
-
-Debugger.html requires two things to run in order to work, a websocket-proxy and webpack. Both of these tools are started by `npm start`.
-
-```js
-npm start
-```
-
-### 5. View the Debugger
+Go to the Debugger!
 
 ```
 $ open index.html
 ```
+
+
+#### Advanced
+
+##### User Configuration
+
+You can add an `environment.json` to set user environmental variables, like the firefox source path. Start by copying the environment.sample.
+
+```json
+{ "firefoxSrcPath" : "/Users/jlaster/src/mozilla/gecko-dev"}
+```
+
+##### Remote Debugging
+If you'd like to connect an existing browser to debugger.html, you can press "shift+F2" and type "listen" with the port 6080.

--- a/environment.sample
+++ b/environment.sample
@@ -1,0 +1,3 @@
+{
+  "firefoxSrcDir": "/Users/jlaster/src/mozilla/gecko-dev/"
+}

--- a/js/components/SplitBox.js
+++ b/js/components/SplitBox.js
@@ -6,7 +6,7 @@ const React = require("react");
 const ReactDOM = require("react-dom");
 const { assert } = require("devtools/shared/DevToolsUtils");
 const Draggable = React.createFactory(require("./Draggable"));
-require('themes/components-h-split-box.css');
+require('../lib/themes/components-h-split-box.css');
 
 const { DOM: dom, PropTypes } = React;
 

--- a/js/lib/themes/components-h-split-box.css
+++ b/js/lib/themes/components-h-split-box.css
@@ -1,0 +1,31 @@
+/* vim:set ts=2 sw=2 sts=2 et: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * HSplitBox Component
+ * Styles for React component at `devtools/client/shared/components/h-split-box.js`
+ */
+
+.h-split-box,
+.h-split-box-pane {
+  overflow: auto;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.h-split-box {
+  display: flex;
+  flex-direction: row;
+  flex: 1;
+}
+
+.h-split-box-splitter {
+  -moz-border-end: 1px solid var(--theme-splitter-color);
+  cursor: ew-resize;
+  width: 3px;
+  -moz-margin-start: -3px;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
-const environment = require('./environment.json');
 
 module.exports = {
   entry: './js/main.js',
@@ -12,8 +11,7 @@ module.exports = {
   resolve: {
     alias: {
       "devtools": "ff-devtools-libs",
-      "sdk": "ff-devtools-libs/sdk",
-      "themes": environment.geckoPath + "devtools/client/themes"
+      "sdk": "ff-devtools-libs/sdk"
     },
     extensions: ["", ".js", ".jsm"],
     root: path.join(__dirname, "node_modules")


### PR DESCRIPTION
This patch removes the firefox dependency:

+ moves split-box.css into lib
+ removes the webpack.config dependency on environment.json
+ updates the readme so environment.json is optional

It also:
+ adds an environment.json.sample file